### PR TITLE
Fix version check

### DIFF
--- a/mu-plugins/code-review-response-form.php
+++ b/mu-plugins/code-review-response-form.php
@@ -226,7 +226,7 @@ function kts_review_response_form_redirect() {
 
 	# Check that URL to download software is to a later release	
 	$download_link = get_post_meta( $software_id, 'download_link', true );
-	preg_match( '~releases\/download\/v?[\s\S]+\/~', $download_link, $orig_matches );
+	preg_match( '~releases\/download\/v?[\s\S]+?\/~', $download_link, $orig_matches );
 	$orig_version = str_replace( ['releases/download/v', 'releases/download/', '/'], '', $orig_matches[0] );
 
 	$new_link = esc_url_raw( wp_unslash( $_POST['download_link'] ) );

--- a/mu-plugins/code-review-response-form.php
+++ b/mu-plugins/code-review-response-form.php
@@ -226,12 +226,12 @@ function kts_review_response_form_redirect() {
 
 	# Check that URL to download software is to a later release	
 	$download_link = get_post_meta( $software_id, 'download_link', true );
-	preg_match( '~releases\/download\/v[\s\S]+?\/~', $download_link, $orig_matches );
-	$orig_version = str_replace( ['releases/download/v', '/'], '', $orig_matches[0] );
+	preg_match( '~releases\/download\/v?[\s\S]+\/~', $download_link, $orig_matches );
+	$orig_version = str_replace( ['releases/download/v', 'releases/download/', '/'], '', $orig_matches[0] );
 
 	$new_link = esc_url_raw( wp_unslash( $_POST['download_link'] ) );
-	preg_match( '~releases\/download\/v[\s\S]+?\/~', $new_link, $new_matches );
-	$new_version = str_replace( ['releases/download/v', '/'], '', $new_matches[0] );
+	preg_match( '~releases\/download\/v?[\s\S]+?\/~', $new_link, $new_matches );
+	$new_version = str_replace( ['releases/download/v', 'releases/download/', '/'], '', $new_matches[0] );
 
 	if ( version_compare( $new_version, $orig_version ) !== 1 ) {
 		wp_safe_redirect( esc_url_raw( $referer . '?notification=no-later-link' ) );


### PR DESCRIPTION
Valid version number can start with `v` or not.
When submitting a `code-review-response-form` form the version is wrongly determined if it doesn't start with a `v`. 

> Is “v1.2.3” a semantic version?

> No, “v1.2.3” is not a semantic version. However, prefixing a semantic version with a “v” is a common way (in English) to indicate it is a version number. Abbreviating “version” as “v” is often seen with version control. Example: git tag v1.2.3 -m "Release version 1.2.3", in which case “v1.2.3” is a tag name and the semantic version is “1.2.3”. 