### PR TITLE
Add autocompletion to code-review-response-form in e-mail link

### DIFF
--- a/mu-plugins/code-review-response-form.php
+++ b/mu-plugins/code-review-response-form.php
@@ -87,34 +87,51 @@ function kts_render_review_response_form() {
 				echo '<div class="success-message" role="polite"><p>' . __( 'Your comments have been submitted successfully. Your reviewer will respond by email.', 'classicpress' ) . '</p></div>';
 			}
 		}
+
+		# Get info from query
+		if ( isset( $_REQUEST['reviewed-item-name'] ) ) {
+			$precompiled_name = 'value="' . sanitize_text_field( wp_unslash( $_REQUEST['reviewed-item-name'] ) ) . '"';
+		} else {
+			$precompiled_name = '';
+		}
+		if ( isset( $_REQUEST['reviewed-item-id'] ) ) {
+			$precompiled_id = 'value="' . (int) wp_unslash( $_REQUEST['reviewed-item-id'] ) . '"';
+		} else {
+			$precompiled_id = '';
+		}
+		if ( isset( $_REQUEST['reviewed-item-type'] ) && in_array( $_REQUEST['reviewed-item-type'], ['plugin', 'theme', 'snippet'] ) ) {
+			$precompiled_type = wp_unslash( $_REQUEST['reviewed-item-type'] );
+		} else {
+			$precompiled_type = '';
+		}
 		?>
 
 		<form id="review-code-response-form" method="post" autocomplete="off">
 
 			<label for="name"><?php _e( 'Name of Software', 'classicpress' ); ?></label>
-			<input id="name" name="name" type="text" required>
+			<input id="name" name="name" type="text" <?php echo $precompiled_name; ?> required>
 
 			<fieldset>
 				<legend><?php _e( 'Select Type of Software', 'classicpress' ); ?></legend>
 				<div class="clear"></div>
 				<label for="plugin">
-					<input id="plugin" class="mgr-lg" name="software-type" type="radio" value="plugin" required>
+					<input id="plugin" class="mgr-lg" name="software-type" type="radio" value="plugin" <?php checked( $precompiled_type, 'plugin') ?> required>
 					Plugin
 				</label>
 				<br>
 				<label for="theme">
-					<input id="theme" class="mgr-lg" name="software-type" type="radio" value="theme" required>
+					<input id="theme" class="mgr-lg" name="software-type" type="radio" value="theme" <?php checked( $precompiled_type, 'theme') ?> required>
 					Theme
 				</label>
 				<br>
 				<label for="snippet">
-					<input id="snippet" class="mgr-lg" name="software-type" type="radio" value="snippet" required>
+					<input id="snippet" class="mgr-lg" name="software-type" type="radio" value="snippet" <?php checked( $precompiled_type, 'snippet') ?> required>
 					Code Snippet
 				</label>
 			</fieldset>
 
 			<label for="software_id"><?php _e( 'Software ID (shown on the review)', 'classicpress' ); ?></label>
-			<input id="software_id" name="software_id" type="number" min="1" required>
+			<input id="software_id" name="software_id" type="number" min="1" <?php echo $precompiled_id; ?> required>
 
 			<label for="comments"><?php _e( 'Comments in response to code review', 'classicpress' ); ?></label>
 			<textarea id="comments" name="comments" required></textarea>
@@ -151,7 +168,7 @@ function kts_review_response_form_redirect() {
 
 	# If nonce is wrong
 	$nonce = cp_check_nonce( $_POST['cp-response-name'], $_POST['cp-response-value'] );
-	$referer = remove_query_arg( 'notification', wp_get_referer() );
+	$referer = remove_query_arg( [ 'notification', 'reviewed-item-name', 'reviewed-item-id', 'reviewed-item-type' ] , wp_get_referer() );
 
 	if ( $nonce === false ) {
 		wp_safe_redirect( esc_url_raw( $referer . '?notification=nonce-wrong' ) );

--- a/mu-plugins/reviews.php
+++ b/mu-plugins/reviews.php
@@ -236,8 +236,8 @@ function kts_email_faculty_protocol( $new_status, $old_status, $post ) {
 
 	$subject = 'Review of ' . esc_html( $software->post_title ) . ': ' . esc_html( ucwords( $software->post_type ) ) . ' Submission ID #' . absint( $software_ids[0] );
 
-	$message = esc_html( $post->post_content ) . '<p>Please do not respond to this review by email, as this email address is not monitored. If you need to modify your code to comply with the requirements of the review, you should use the <a href="' . esc_url( home_url( '/code-review-response-form/' ) ) . '">Code Review Response Form</a>. If you simply wish to ask a question, you should do that on Slack or the <a href="https://forums.classicpress.net/">ClassicPress forums</a>.</p>';
-	
+	$message = esc_html( $post->post_content ) . '<p>Please do not respond to this review by email, as this email address is not monitored. If you need to modify your code to comply with the requirements of the review, you should use the <a href="' . esc_url( home_url( '/code-review-response-form/?reviewed-item-id=' . absint( $software_ids[0] ) . '&reviewed-item-name=' . urlencode( $software->post_title ) . '&reviewed-item-type=' . $software->post_type ) ) . '">Code Review Response Form</a>. If you simply wish to ask a question, you should do that on Slack or the <a href="https://forums.classicpress.net/">ClassicPress forums</a>.</p>';
+
 	$headers = array( 'Content-Type: text/html; charset=UTF-8' );
 
 	wp_mail( $author->user_email, $subject, $message, $headers );


### PR DESCRIPTION
Changed the link that is in the review e-mail so it can autocomplete fields in the form.

Before:
<img width="907" alt="Schermata 2022-07-25 alle 13 49 52" src="https://user-images.githubusercontent.com/29772709/180781657-2282e8c0-452a-4eee-ac55-f63314c54d5d.png">

After:
<img width="903" alt="Schermata 2022-07-25 alle 13 50 12" src="https://user-images.githubusercontent.com/29772709/180781676-152bf666-227c-4b7b-bc4b-bd30c97de665.png">

