### PR TITLE
Get headers from ZIP

### DIFF
--- a/mu-plugins/software-submit-form.php
+++ b/mu-plugins/software-submit-form.php
@@ -441,8 +441,6 @@ function kts_software_submit_form_redirect() {
 		}
 	}
 
-trigger_error(print_r($headers, true));
-trigger_error(print_r($main_plugin_file, true));
 	# Delete temporary file
 	wp_delete_file( $file['tmp_name'] );
 


### PR DESCRIPTION
This PR substitutes #18 that can be closed.

Get headers from submitted ZIP file.
`$headers` contains the plugin headers.
`$main_plugin_file` contain the relative path of the plugin main file (like `doit/bad.php`).

You can test plugin doing thing not in the proper way using my [Do It Bad](https://github.com/xxsimoxx/doit/releases/download/v1.0.0/doit-1.0.0.zip) plugin.

