### PR TITLE
Fix headers coming from last parsed file

### DIFF
--- a/mu-plugins/software-submit-form.php
+++ b/mu-plugins/software-submit-form.php
@@ -494,12 +494,16 @@ function kts_software_submit_form_redirect() {
 			# Parse other files for headers
 			for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 				if ( ! preg_match( '~\.php$~', $zip->getNameIndex( $i ) ) || substr_count( $zip->getNameIndex( $i ), '/' ) !== 1 ) {
-
 					# Only check PHP and don't recourse into subdirs
 					continue;
 				}
 				$file_data = $zip->getFromIndex( $i, 8192 );
 				$headers = kts_get_plugin_data( $file_data );
+				if ( ! empty( $headers['RequiresPHP'] ) ) {
+					# We have the headers
+					$main_plugin_file = $zip->getNameIndex( $i );
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When looping through files we missed a break, so headers come from the last parsed file, so maybe empty.