### PR TITLE
Remove from developer list users without published entries

### DIFF
--- a/themes/classicpress-directory/inc/template-functions.php
+++ b/themes/classicpress-directory/inc/template-functions.php
@@ -165,6 +165,7 @@ function kts_purge_developers_cache( $user_id ) {
 }
 add_action( 'user_register', 'kts_purge_developers_cache' );
 add_action( 'delete_user', 'kts_purge_developers_cache' );
+add_action( 'profile_update', 'kts_purge_developers_cache' );
 
 function kts_purge_developers_cpt_cache( $post_id ) {
 

--- a/themes/classicpress-directory/inc/template-functions.php
+++ b/themes/classicpress-directory/inc/template-functions.php
@@ -132,6 +132,10 @@ function kts_list_developers() {
 
 		if ( ! empty( $users ) ) {
 			foreach ( $users as $user ) {
+				if ( count_user_posts( $user->ID, [ 'plugin', 'theme', 'snippet' ], true ) === '0' ) {
+					continue;
+				}
+
 				$initial = $user->display_name[0]; // first letter
 				if ( $initial !== $previous_initial ) {
 					$developers .= '</ul><ul id="letter-' . strtolower( $initial ) . '-panel" class="developer-panel" role="tabpanel">';


### PR DESCRIPTION
A single user can be a developer and a reviewer.
But a developer without plugins for long time is for sure a reviewer, so filtering in this way makes reviewer's identity more secure.