### PR TITLE
Search by slug in REST API (proposal)

### DIFF
--- a/mu-plugins/rest-api.php
+++ b/mu-plugins/rest-api.php
@@ -254,8 +254,7 @@ function kts_modify_rest_software_routes( $response, $handler, $request ) {
 }
 add_filter( 'rest_request_before_callbacks', 'kts_modify_rest_software_routes', 10, 3 );
 
-add_filter( 'rest_plugin_query', 'filter_posts_by_source_field', 999, 2 );
-function filter_posts_by_source_field( $args, $request ) {
+function kts_filter_posts_by_slug_field( $args, $request ) {
 	if ( ! isset( $request['byslug'] )  ) {
 		return $args;
 	}
@@ -276,3 +275,6 @@ function filter_posts_by_source_field( $args, $request ) {
 	
 	return $args;
 }
+add_filter( 'rest_plugin_query', 'kts_filter_posts_by_slug_field', 999, 2 );
+add_filter( 'rest_theme_query', 'kts_filter_posts_by_slug_field', 999, 2 );
+add_filter( 'rest_snippet_query', 'kts_filter_posts_by_slug_field', 999, 2 );

--- a/mu-plugins/rest-api.php
+++ b/mu-plugins/rest-api.php
@@ -253,3 +253,26 @@ function kts_modify_rest_software_routes( $response, $handler, $request ) {
 	}
 }
 add_filter( 'rest_request_before_callbacks', 'kts_modify_rest_software_routes', 10, 3 );
+
+add_filter( 'rest_plugin_query', 'filter_posts_by_source_field', 999, 2 );
+function filter_posts_by_source_field( $args, $request ) {
+	if ( ! isset( $request['byslug'] )  ) {
+		return $args;
+	}
+	
+	$slug_value = sanitize_text_field( $request['byslug'] );
+	$slug_meta_query = array(
+		'key' => 'slug',
+		'value' => $slug_value
+	);
+	
+	if ( isset( $args['meta_query'] ) ) {
+		$args['meta_query']['relation'] = 'AND';
+		$args['meta_query'][] = $slug_meta_query;
+	} else {
+		$args['meta_query'] = array();
+		$args['meta_query'][] = $slug_meta_query;
+	}
+	
+	return $args;
+}


### PR DESCRIPTION
**Add the option for searching plugins by slug meta.**
`https://dir.educatorecinofilo.dog/wp-json/wp/v2/plugins?byslug=my-nice-slug`.
Note that the similar query
`https://dir.educatorecinofilo.dog/wp-json/wp/v2/plugins?slug=my-nice-slug`
works but on custom post type slug (the plugin name) and not on the plugin slug as in the meta.

As example "Carbon Copy" plugin will have it's page on https://dir.XXX.dog/plugins/carbon-copy/ and `carbon-copy` is the slug considered in the second search, but "Carbon Copy" slug as saved as meta is `codepotent-carbon-copy`. 

Searching for `slug` is the most easy way for what will handle the update process.

**Why I did that?**
I had a quick look backporting `wp-r50921 ` (WP changeset that introduces `Update URI` header and `update_plugins_{$hostname}` filter) and was a 30 minutes job to get a plugin to properly update using the new directory and this PR has the changes I had to introduce to get things working.